### PR TITLE
Support Python 3

### DIFF
--- a/clowncar/backends.py
+++ b/clowncar/backends.py
@@ -5,6 +5,14 @@ from socket import gethostname
 from . import exc
 from .server import Server
 
+# Handle string detection without adding a dependency on any external modules.
+try:
+    basestring = basestring
+    bytes = str
+except NameError:
+    # basestring is undefined, must be Python 3.
+    basestring = (str, bytes)
+
 
 class Backends(object):
     def __init__(self, servers, partition_key):
@@ -70,7 +78,9 @@ class Backends(object):
 
         if callable(partition_key):
             return partition_key
-        elif isinstance(partition_key, basestring):
+        elif isinstance(partition_key, bytes):
             return lambda: partition_key
+        elif isinstance(partition_key, basestring):
+            return lambda: partition_key.encode()
 
         raise TypeError("Invalid type to partition_key argument.")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ kwargs = {
     "url": "https://github.com/gmjosack/clowncar",
     "download_url": "https://github.com/gmjosack/clowncar/archive/master.tar.gz",
     "classifiers": [
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Add a mildly awkward workaround for basestring, and encode unicode
strings before passing them to the MD5 hash function.

Update the Trove classifiers to declare compatibility with both
Python 2 and Python 3.